### PR TITLE
fix(react): properly pass 'style' prop to Kanva root element

### DIFF
--- a/packages/react/src/kanva.react-view.tsx
+++ b/packages/react/src/kanva.react-view.tsx
@@ -70,12 +70,12 @@ export class Kanva extends React.PureComponent<Props, State> {
   setDivElement = (ref: HTMLDivElement) => this.htmlDivElement = ref;
 
   render() {
-    const { className, children, canvasRef } = this.props;
+    const { className, children, canvasRef, style } = this.props;
     const { view } = this.state;
     return (
       <div
         ref={this.setDivElement}
-        style={{ position: 'relative' }}
+        style={{ ...style, position: 'relative' }}
         className={className}
       >
         <canvas


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/kanva/kanva/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) - **not applicable**


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Infrastructure / API changes
- [ ] Other <!-- Please describe -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `style` prop is not forwarded to `Kanva` component root element.


## What is the new behavior?
The `style` prop is forwarded to `Kanva` component root element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
