### PR TITLE
fix(npm): move tslib from dev dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
   "release": {
     "branch": "master"
   },
+  "dependencies": {
+    "tslib": "^2.1.0"
+  },
   "devDependencies": {
     "@types/d3-scale": "^2.1.1",
     "@types/jest": "^27.0.3",
@@ -67,7 +70,6 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "ts-jest": "^27.1.1",
-    "tslib": "^2.3.1",
     "typedoc": "^0.19.2",
     "typedoc-plugin-markdown": "^2.2.17",
     "typescript": "^4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20517,7 +20517,7 @@ tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^2.3.1:
+tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/kanva/kanva/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Infrastructure / API changes
- [ ] Other <!-- Please describe -->


## What is the current behavior?
the `tslib` have to be added manually by anyone wanting to use kanva library


## What is the new behavior?
the `tslib` doesn't have to be added manually by anyone wanting to use kanva library due to it being marked as direct project dependency

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
